### PR TITLE
shorten vertical padding with react native's paddingVertical style prop

### DIFF
--- a/albums/src/components/Button.js
+++ b/albums/src/components/Button.js
@@ -19,8 +19,7 @@ const styles = {
     color: '#007aff',
     fontSize: 16,
     fontWeight: '600',
-    paddingTop: 10,
-    paddingBottom: 10
+    paddingVertical: 10
   },
   buttonStyle: {
     flex: 1,


### PR DESCRIPTION
in case you want to use this shorter style syntax react native provides for such vertical margin/padding stylings
